### PR TITLE
Updating SimpleSQSFunction blueprint for netcore 3.1

### DIFF
--- a/Blueprints/BlueprintDefinitions/netcore3.1/SimpleSQSFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
+++ b/Blueprints/BlueprintDefinitions/netcore3.1/SimpleSQSFunction/template/src/BlueprintBaseName.1/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "DefaultProfile",
   "region": "DefaultRegion",
   "configuration": "Release",
-  "framework": "netcoreapp2.0",
-  "function-runtime": "dotnetcore2.0",
+  "framework": "netcoreapp3.1",
+  "function-runtime": "dotnetcore3.1",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "BlueprintBaseName.1::BlueprintBaseName._1.Function::FunctionHandler"


### PR DESCRIPTION
The current netcore 3.1 blueprint sets the `aws-lambda-tools-defaults.json` file to use `netcore 2.0` - this causes the publish cli actions to fail per https://github.com/aws/aws-extensions-for-dotnet-cli/issues/139

Updating this to `netcore-3.1` fixes associated build and publish functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
